### PR TITLE
require pandas 1.0 because of parquet schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "qpd>=0.2.4",
         "sqlalchemy",
         "pyarrow>=0.15.1",
-        "pandas>=1.0.0",
+        "pandas>=1.0.2",
     ],
     extras_require={
         "sql": ["antlr4-python3-runtime", "jinja2"],

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "qpd>=0.2.4",
         "sqlalchemy",
         "pyarrow>=0.15.1",
+        "pandas>=1.0.0",
     ],
     extras_require={
         "sql": ["antlr4-python3-runtime", "jinja2"],


### PR DESCRIPTION
This is to prevent issues with the NativeExecutionEngine writing out parquets.

To see more: read https://github.com/fugue-project/fugue/issues/45