### PR TITLE
Fix jinja render with keyword in template

### DIFF
--- a/fugue_sql/_utils.py
+++ b/fugue_sql/_utils.py
@@ -3,22 +3,18 @@ import re
 from jinja2 import Template
 from typing import Dict, Any
 
+MATCH_QUOTED_STRING = r"([\"'])(.*?[^\\])\1"
+
 
 def fill_sql_template(sql: str, params: Dict[str, Any]):
-    i = 0
-    while i < len(sql):
-        ch = sql[i]
-        if ch == '"':
-            sql = sql[:i] + re.sub(
-                r"\"(.+?)\"", r'"{% raw %}\1{% endraw %}"', sql[i:], 1
-            )
-            i = sql.find('"', i + 1) + 1
-        elif ch == "'":
-            sql = sql[:i] + re.sub(
-                r"\'(.+?)\'", r"'{% raw %}\1{% endraw %}'", sql[i:], 1
-            )
-            i = sql.find("'", i + 1) + 1
-        else:
-            i += 1
+    single_quote_pattern = "'{{% raw %}}{}{{% endraw %}}'"
+    double_quote_pattern = '"{{% raw %}}{}{{% endraw %}}"'
+    sql = re.sub(
+        MATCH_QUOTED_STRING,
+        lambda pattern: double_quote_pattern.format(pattern.group(2))
+        if pattern.group(1) == '"'
+        else single_quote_pattern.format(pattern.group(2)),
+        sql,
+    )
     template = Template(sql)
     return template.render(**params)

--- a/fugue_sql/_utils.py
+++ b/fugue_sql/_utils.py
@@ -1,7 +1,24 @@
+import re
+
 from jinja2 import Template
 from typing import Dict, Any
 
 
 def fill_sql_template(sql: str, params: Dict[str, Any]):
+    i = 0
+    while i < len(sql):
+        ch = sql[i]
+        if ch == '"':
+            sql = sql[:i] + re.sub(
+                r"\"(.+?)\"", r'"{% raw %}\1{% endraw %}"', sql[i:], 1
+            )
+            i = sql.find('"', i + 1) + 1
+        elif ch == "'":
+            sql = sql[:i] + re.sub(
+                r"\'(.+?)\'", r"'{% raw %}\1{% endraw %}'", sql[i:], 1
+            )
+            i = sql.find("'", i + 1) + 1
+        else:
+            i += 1
     template = Template(sql)
     return template.render(**params)

--- a/tests/fugue_sql/test_utils.py
+++ b/tests/fugue_sql/test_utils.py
@@ -4,6 +4,9 @@ from fugue_sql._utils import fill_sql_template
 def test_fill_sql_template():
     data = {"a": 1, "b": "x"}
     assert "a=select " == fill_sql_template("a=select ", data)
+    assert "a=select * from b like '{%'" == fill_sql_template("a=select * from b like '{%'", data)
+    assert 'a=select * from b like "{%"' == fill_sql_template('a=select * from b like "{%"', data)
+    assert 'a=select * from b like "{%\'{%\'"' == fill_sql_template('a=select * from b like "{%\'{%\'"', data)
     assert "1x1" == fill_sql_template("{{a}}{{b}}{{a}}", data)
     assert "" == fill_sql_template("", data)
     assert "%s" == fill_sql_template("%s", data)

--- a/tests/fugue_sql/test_utils.py
+++ b/tests/fugue_sql/test_utils.py
@@ -7,6 +7,15 @@ def test_fill_sql_template():
     assert "a=select * from b like '{%'" == fill_sql_template("a=select * from b like '{%'", data)
     assert 'a=select * from b like "{%"' == fill_sql_template('a=select * from b like "{%"', data)
     assert 'a=select * from b like "{%\'{%\'"' == fill_sql_template('a=select * from b like "{%\'{%\'"', data)
+    assert 'a=select * from b like "%}"' == fill_sql_template('a=select * from b like "%}"', data)
+    assert 'a=select * from b like "{% for env in (\'dev\', \'prod\') %}"' == fill_sql_template('a=select * from b like "{% for env in (\'dev\', \'prod\') %}"', data)
+    assert 'a=select * from b like "{% for env in (\'dev\', \'prod\') %}{% endfor %}"' == fill_sql_template('a=select * from b like "{% for env in (\'dev\', \'prod\') %}{% endfor %}"', data)
+
+    assert "a=select * from b like '{%'" == fill_sql_template("a=select * from b like '{%'", data)
+    assert "a=select * from b like '%}'" == fill_sql_template("a=select * from b like '%}'", data)
+    assert "a=select * from b like '{% for env in (\'dev\', \'prod\') %}'" == fill_sql_template("a=select * from b like '{% for env in (\'dev\', \'prod\') %}'", data)
+    assert "a=select * from b like '{% for env in (\'dev\', \'prod\') %}{% endfor %}'" == fill_sql_template("a=select * from b like '{% for env in (\'dev\', \'prod\') %}{% endfor %}'", data)    
+
     assert "1x1" == fill_sql_template("{{a}}{{b}}{{a}}", data)
     assert "" == fill_sql_template("", data)
     assert "%s" == fill_sql_template("%s", data)

--- a/tests/fugue_sql/test_workflow.py
+++ b/tests/fugue_sql/test_workflow.py
@@ -44,6 +44,17 @@ def test_show():
         )
 
 
+def test_jinja_keyword_in_sql():
+    with FugueSQLWorkflow() as dag:
+        dag(
+            """
+        CREATE [["{%'{%'"]] SCHEMA a:str
+        SELECT * WHERE a LIKE '{%'
+        PRINT
+        """
+        )
+
+
 def test_use_df():
     with FugueSQLWorkflow() as dag:
         a = dag.df([[0], [1]], "a:int")


### PR DESCRIPTION
Not sure if it is the safest way to fix the bug.
The idea is if we met a string, we should wrap that string with `{% raw %}` and `{% endraw %}`. 