### PR TITLE
[ISSUE-99] Fix import for output related transformer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ help:
 	@echo "	 testspark	run all tests of spark (assumes venv is present)"
 	@echo "	 sql		fugue sql code gen"
 
+clean:
+	find . -name "__pycache__" |xargs rm -rf
 
 setupinpip:
 	pip3 install -r requirements.txt

--- a/fugue/__init__.py
+++ b/fugue/__init__.py
@@ -17,7 +17,7 @@ from fugue.execution.native_execution_engine import NativeExecutionEngine, Sqlit
 from fugue.extensions.creator import Creator, creator
 from fugue.extensions.outputter import Outputter, outputter
 from fugue.extensions.processor import Processor, processor
-from fugue.extensions import (
+from fugue.extensions.transformer import (
     CoTransformer,
     OutputCoTransformer,
     OutputTransformer,

--- a/fugue/__init__.py
+++ b/fugue/__init__.py
@@ -17,11 +17,15 @@ from fugue.execution.native_execution_engine import NativeExecutionEngine, Sqlit
 from fugue.extensions.creator import Creator, creator
 from fugue.extensions.outputter import Outputter, outputter
 from fugue.extensions.processor import Processor, processor
-from fugue.extensions.transformer import (
+from fugue.extensions import (
     CoTransformer,
+    OutputCoTransformer,
+    OutputTransformer,
     Transformer,
     transformer,
     cotransformer,
+    output_transformer,
+    output_cotransformer,
 )
 from fugue.workflow.workflow import FugueWorkflow, WorkflowDataFrame
 from fugue.workflow._workflow_context import FugueWorkflowContext


### PR DESCRIPTION
Test:
```
❯ python
Python 3.8.2 (v3.8.2:7b3ab5921f, Feb 24 2020, 17:52:18)
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from fugue import output_transformer, output_cotransformer, OutputTransformer, OutputCoTransformer
>>>
```