### PR TITLE
refactor _parse_presort_exp to parse_presort_exp 

### DIFF
--- a/fugue/collections/partition.py
+++ b/fugue/collections/partition.py
@@ -11,10 +11,10 @@ from triad.utils.hash import to_uuid
 
 def parse_presort_exp(presort: Any) -> IndexedOrderedDict[str, bool]:  # noqa: C901
     """Returns ordered column sorting direction where ascending order
-    is true, descending is false.
+    would return as true, and descending as false.
 
     Args:
-        presort (Any): string or tuple of column order direction
+        presort (Any): string that contains columns and sorting direction
 
     Returns:
         IndexedOrderedDict[str, bool]: column and sorting direction

--- a/fugue/collections/partition.py
+++ b/fugue/collections/partition.py
@@ -9,17 +9,22 @@ from triad.utils.pyarrow import SchemaedDataPartitioner
 from triad.utils.hash import to_uuid
 
 
-def parse_presort_exp(presort: Any) -> IndexedOrderedDict[str, bool]:  # noqa: C901
+def parse_presort_exp(presort: Any) -> IndexedOrderedDict[str, bool]:  # noqa [C901]
     """Returns ordered column sorting direction where ascending order
     would return as true, and descending as false.
 
-    Args:
-        presort (Any): string that contains column and sorting direction or
+    :param presort: string that contains column and sorting direction or
         list of tuple that contains column and boolean sorting direction
+    :type presort: Any
 
-    Returns:
-        IndexedOrderedDict[str, bool]: column and boolean sorting direction
-        of column, order matters.
+    :return: column and boolean sorting direction of column, order matters.
+    :rtype: IndexedOrderedDict[str, bool]
+
+    :Example:
+
+    >>> parse_presort_exp("b desc, c asc")
+    >>> parse_presort_exp([("b", True), ("c", False))])
+    both return IndexedOrderedDict([("b", True), ("c", False))])
     """
 
     if isinstance(presort, IndexedOrderedDict):

--- a/fugue/collections/partition.py
+++ b/fugue/collections/partition.py
@@ -14,10 +14,11 @@ def parse_presort_exp(presort: Any) -> IndexedOrderedDict[str, bool]:  # noqa: C
     would return as true, and descending as false.
 
     Args:
-        presort (Any): string that contains columns and sorting direction
+        presort (Any): string that contains column and sorting direction or
+        list of tuple that contains column and boolean sorting direction
 
     Returns:
-        IndexedOrderedDict[str, bool]: column and sorting direction
+        IndexedOrderedDict[str, bool]: column and boolean sorting direction
         of column, order matters.
     """
 

--- a/fugue/collections/partition.py
+++ b/fugue/collections/partition.py
@@ -9,7 +9,7 @@ from triad.utils.pyarrow import SchemaedDataPartitioner
 from triad.utils.hash import to_uuid
 
 
-def _parse_presort_exp(presort: Any) -> IndexedOrderedDict[str, bool]:  # noqa: C901
+def parse_presort_exp(presort: Any) -> IndexedOrderedDict[str, bool]:  # noqa: C901
     if isinstance(presort, IndexedOrderedDict):
         return presort
 
@@ -109,7 +109,7 @@ class PartitionSpec(object):
             len(self._partition_by) == len(set(self._partition_by)),
             SyntaxError(f"{self._partition_by} has duplicated keys"),
         )
-        self._presort = _parse_presort_exp(p.get_or_none("presort", object))
+        self._presort = parse_presort_exp(p.get_or_none("presort", object))
         if any(x in self._presort for x in self._partition_by):
             raise SyntaxError(
                 "partition by overlap with presort: "

--- a/fugue/collections/partition.py
+++ b/fugue/collections/partition.py
@@ -10,6 +10,17 @@ from triad.utils.hash import to_uuid
 
 
 def parse_presort_exp(presort: Any) -> IndexedOrderedDict[str, bool]:  # noqa: C901
+    """Returns ordered column sorting direction where ascending order
+    is true, descending is false.
+
+    Args:
+        presort (Any): string or tuple of column order direction
+
+    Returns:
+        IndexedOrderedDict[str, bool]: column and sorting direction
+        of column, order matters.
+    """
+
     if isinstance(presort, IndexedOrderedDict):
         return presort
 

--- a/fugue/execution/native_execution_engine.py
+++ b/fugue/execution/native_execution_engine.py
@@ -7,7 +7,7 @@ from fugue.collections.partition import (
     EMPTY_PARTITION_SPEC,
     PartitionCursor,
     PartitionSpec,
-    _parse_presort_exp,
+    parse_presort_exp,
 )
 from fugue.dataframe import (
     DataFrame,
@@ -299,7 +299,7 @@ class NativeExecutionEngine(ExecutionEngine):
 
         # Use presort over partition_spec.presort if possible
         if presort:
-            presort = _parse_presort_exp(presort)
+            presort = parse_presort_exp(presort)
         _presort: IndexedOrderedDict = presort or partition_spec.presort
 
         if len(_presort.keys()) > 0:

--- a/fugue/extensions/_utils.py
+++ b/fugue/extensions/_utils.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict
 
 from fugue._utils.interfaceless import parse_comment_annotation
-from fugue.collections.partition import PartitionSpec, _parse_presort_exp
+from fugue.collections.partition import PartitionSpec, parse_presort_exp
 from fugue.exceptions import (
     FugueWorkflowCompileValidationError,
     FugueWorkflowRuntimeValidationError,
@@ -36,7 +36,7 @@ def to_validation_rules(data: Dict[str, Any]) -> Dict[str, Any]:
                 v = [x.strip() for x in v.split(",")]
             res[k] = PartitionSpec(by=v).partition_by
         elif k in ["presort_has", "presort_is"]:
-            res[k] = list(_parse_presort_exp(v).items())
+            res[k] = list(parse_presort_exp(v).items())
         elif k in ["input_has"]:
             if isinstance(v, str):
                 res[k] = v.replace(" ", "").split(",")

--- a/fugue_dask/execution_engine.py
+++ b/fugue_dask/execution_engine.py
@@ -7,7 +7,7 @@ from fugue.collections.partition import (
     EMPTY_PARTITION_SPEC,
     PartitionCursor,
     PartitionSpec,
-    _parse_presort_exp,
+    parse_presort_exp,
 )
 from fugue.constants import KEYWORD_CORECOUNT, KEYWORD_ROWCOUNT
 from fugue.dataframe import DataFrame, DataFrames, LocalDataFrame, PandasDataFrame
@@ -373,7 +373,7 @@ class DaskExecutionEngine(ExecutionEngine):
         meta = [(d[x].name, d[x].dtype) for x in d.columns]
 
         if presort:
-            presort = _parse_presort_exp(presort)
+            presort = parse_presort_exp(presort)
         # Use presort over partition_spec.presort if possible
         _presort: IndexedOrderedDict = presort or partition_spec.presort
 

--- a/fugue_spark/execution_engine.py
+++ b/fugue_spark/execution_engine.py
@@ -9,7 +9,7 @@ from fugue.collections.partition import (
     EMPTY_PARTITION_SPEC,
     PartitionCursor,
     PartitionSpec,
-    _parse_presort_exp,
+    parse_presort_exp,
 )
 from fugue.constants import KEYWORD_ROWCOUNT
 from fugue.dataframe import DataFrame, DataFrames, IterableDataFrame, LocalDataFrame
@@ -449,7 +449,7 @@ class SparkExecutionEngine(ExecutionEngine):
         nulls_last = bool(na_position == "last")
 
         if presort:
-            presort = _parse_presort_exp(presort)
+            presort = parse_presort_exp(presort)
         # Use presort over partition_spec.presort if possible
         _presort: IndexedOrderedDict = presort or partition_spec.presort
 

--- a/tests/fugue/collections/test_partition.py
+++ b/tests/fugue/collections/test_partition.py
@@ -6,6 +6,26 @@ from pytest import raises
 from triad.collections.schema import Schema
 from triad.utils.hash import to_uuid
 
+def test_parse_presort_exp():
+
+    assert parse_presort_exp() == IndexedOrderedDict()
+    assert parse_presort_exp("c") == IndexedOrderedDict([('c', True)])
+    assert parse_presort_exp("         c") == IndexedOrderedDict([('c', True)])
+    assert parse_presort_exp("c           desc")  == IndexedOrderedDict([('c', False)])
+    assert parse_presort_exp("DESC DESC, ASC ASC") == IndexedOrderedDict([('DESC', False), ('ASC', True)])
+    assert parse_presort_exp("B DESC, C ASC")  == IndexedOrderedDict([('B', False), ('C', True)])
+    assert parse_presort_exp("b desc, c asc") == IndexedOrderedDict([('b', False), ('c', True)])
+    assert parse_presort_exp([("b", "desc"),("c", "asc")]) == IndexedOrderedDict([('b', False), ('c', True)])
+
+    with raises(SyntaxError):
+        parse_presort_exp("b dsc, c asc")
+
+    with raises(SyntaxError):
+        parse_presort_exp("c true")
+
+    with raises(SyntaxError):
+        parse_presort_exp("c true, c true")
+
 
 def test_partition_spec():
     p = PartitionSpec()

--- a/tests/fugue/collections/test_partition.py
+++ b/tests/fugue/collections/test_partition.py
@@ -1,21 +1,22 @@
 import json
 
-from fugue.collections.partition import PartitionSpec
+from fugue.collections.partition import parse_presort_exp, PartitionSpec
 from fugue.constants import KEYWORD_CORECOUNT, KEYWORD_ROWCOUNT
 from pytest import raises
 from triad.collections.schema import Schema
 from triad.utils.hash import to_uuid
+from triad.collections.dict import IndexedOrderedDict
 
 def test_parse_presort_exp():
 
-    assert parse_presort_exp() == IndexedOrderedDict()
+    assert parse_presort_exp(None) == IndexedOrderedDict()
     assert parse_presort_exp("c") == IndexedOrderedDict([('c', True)])
     assert parse_presort_exp("         c") == IndexedOrderedDict([('c', True)])
     assert parse_presort_exp("c           desc")  == IndexedOrderedDict([('c', False)])
     assert parse_presort_exp("DESC DESC, ASC ASC") == IndexedOrderedDict([('DESC', False), ('ASC', True)])
     assert parse_presort_exp("B DESC, C ASC")  == IndexedOrderedDict([('B', False), ('C', True)])
     assert parse_presort_exp("b desc, c asc") == IndexedOrderedDict([('b', False), ('c', True)])
-    assert parse_presort_exp([("b", "desc"),("c", "asc")]) == IndexedOrderedDict([('b', False), ('c', True)])
+    
 
     with raises(SyntaxError):
         parse_presort_exp("b dsc, c asc")
@@ -25,6 +26,9 @@ def test_parse_presort_exp():
 
     with raises(SyntaxError):
         parse_presort_exp("c true, c true")
+
+    with raises(SyntaxError):
+        parse_presort_exp([("b", "desc"),("c", "asc")])
 
 
 def test_partition_spec():

--- a/tests/fugue/collections/test_partition.py
+++ b/tests/fugue/collections/test_partition.py
@@ -10,6 +10,7 @@ from triad.collections.dict import IndexedOrderedDict
 def test_parse_presort_exp():
 
     assert parse_presort_exp(None) == IndexedOrderedDict()
+    assert parse_presort_exp(IndexedOrderedDict([('c', True)])) == IndexedOrderedDict([('c', True)])
     assert parse_presort_exp("c") == IndexedOrderedDict([('c', True)])
     assert parse_presort_exp("         c") == IndexedOrderedDict([('c', True)])
     assert parse_presort_exp("c           desc")  == IndexedOrderedDict([('c', False)])

--- a/tests/fugue/collections/test_partition.py
+++ b/tests/fugue/collections/test_partition.py
@@ -14,22 +14,24 @@ def test_parse_presort_exp():
     assert parse_presort_exp("c") == IndexedOrderedDict([('c', True)])
     assert parse_presort_exp("         c") == IndexedOrderedDict([('c', True)])
     assert parse_presort_exp("c           desc")  == IndexedOrderedDict([('c', False)])
+    assert parse_presort_exp("b desc, c asc")  == IndexedOrderedDict([('b', False), ('c', True)])
     assert parse_presort_exp("DESC DESC, ASC ASC") == IndexedOrderedDict([('DESC', False), ('ASC', True)])
+    assert parse_presort_exp([("b", False),("c", True)]) == IndexedOrderedDict([('b', False), ('c', True)])
     assert parse_presort_exp("B DESC, C ASC")  == IndexedOrderedDict([('B', False), ('C', True)])
     assert parse_presort_exp("b desc, c asc") == IndexedOrderedDict([('b', False), ('c', True)])
     
 
     with raises(SyntaxError):
-        parse_presort_exp("b dsc, c asc")
+        parse_presort_exp("b dsc, c asc") # mispelling of desc
 
     with raises(SyntaxError):
-        parse_presort_exp("c true")
+        parse_presort_exp("c true") # string format needs desc/asc
 
     with raises(SyntaxError):
-        parse_presort_exp("c true, c true")
+        parse_presort_exp("c true, c true") # cannot contain duplicates
 
     with raises(SyntaxError):
-        parse_presort_exp([("b", "desc"),("c", "asc")])
+        parse_presort_exp([("b", "desc"),("c", "asc")]) # instead of desc and asc, needs to be bool
 
 
 def test_partition_spec():


### PR DESCRIPTION
made _parse_presort_exp a public function in the following modules

`/root/workspace/fugue/fugue/collections/partition.py      
/root/workspace/fugue/fugue/execution/native_execution_engine.py     
/root/workspace/fugue/fugue/extensions/_utils.py     
/root/workspace/fugue/fugue_dask/execution_engine.py      
/root/workspace/fugue/fugue_spark/execution_engine.py`