### PR TITLE
simplify schema, make save_df consistent for avro and increase coverage

### DIFF
--- a/tests/fugue_spark/utils/test_io.py
+++ b/tests/fugue_spark/utils/test_io.py
@@ -9,7 +9,7 @@ from fugue_spark._utils.convert import to_schema, to_spark_schema
 from fugue_spark._utils.io import SparkIO
 from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
-from pytest import raises, mark
+from pytest import raises
 from triad.collections.fs import FileSystem
 from triad.exceptions import InvalidOperationError
 


### PR DESCRIPTION
- simplify schema input and remove the columns arg in `_save_avro` since other save functions don't have columns arg
- `pytest -svv tests/fugue/utils/test_io.py` now has 100% cov of `fugue/_utils/io.py`