### PR TITLE
fix an edge case

### DIFF
--- a/fugue_sql/workflow.py
+++ b/fugue_sql/workflow.py
@@ -79,7 +79,9 @@ class FugueSQLWorkflow(FugueWorkflow):
         p: Dict[str, Any] = {}
         dfs: Dict[str, LazyWorkflowDataFrame] = {}
         for k, v in params.items():
-            if isinstance(v, (DataFrame, Yielded)) or is_acceptable_raw_df(v):
+            if isinstance(v, (int, str, float, bool)):
+                p[k] = v
+            elif isinstance(v, (DataFrame, Yielded)) or is_acceptable_raw_df(v):
                 dfs[k] = LazyWorkflowDataFrame(k, v, self)
             else:
                 p[k] = v

--- a/tests/fugue_sql/test_utils.py
+++ b/tests/fugue_sql/test_utils.py
@@ -3,31 +3,35 @@ from fugue_sql._utils import fill_sql_template
 
 def test_fill_sql_template():
     data = {"a": 1, "b": "x"}
-    assert ( "select * from tbl where a = 1 and b = 'x'" 
-    == fill_sql_template("select * from tbl where a = {{a}} and b = '{{b}}'", data)
+    assert "select * from tbl where a = 1 and b = 'x'" == fill_sql_template(
+        "select * from tbl where a = {{a}} and b = '{{b}}'", data
     )
-    assert ("""select * from tbl where a = 1 and b = "x" """ 
-    == fill_sql_template("""select * from tbl where a = {{a}} and b = "{{b}}" """, data)
+    assert """select * from tbl where a = 1 and b = "x" """ == fill_sql_template(
+        """select * from tbl where a = {{a}} and b = "{{b}}" """, data
     )
 
-    assert ( """select * where b="%x" """
-    == fill_sql_template("""select * where b="%{{b}}" """, data))
-    assert ( """select * where b="x%" """ 
-    == fill_sql_template("""select * where b="{{b}}%" """, data))
+    assert """select * where b="%x" """ == fill_sql_template(
+        """select * where b="%{{b}}" """, data
+    )
+    assert """select * where b="x%" """ == fill_sql_template(
+        """select * where b="{{b}}%" """, data
+    )
 
-    assert ( """select * b like "{}%{}" """
-     == fill_sql_template("""select * b like "{}%{}" """, data))
-    assert ( """select * b like '%}' """
-    == fill_sql_template("""select * b like '%}' """, data))
-    assert ("""select * where b="%x" """ 
-    == fill_sql_template("""select * where b="%{{b}}" """, data)
+    assert """select * b like "{}%{}" """ == fill_sql_template(
+        """select * b like "{}%{}" """, data
     )
-    assert ("""select * where b="x%" """ 
-    == fill_sql_template("""select * where b="{{b}}%" """, data)
+    assert """select * b like '%}' """ == fill_sql_template(
+        """select * b like '%}' """, data
     )
-    
+    assert """select * where b="%x" """ == fill_sql_template(
+        """select * where b="%{{b}}" """, data
+    )
+    assert """select * where b="x%" """ == fill_sql_template(
+        """select * where b="{{b}}%" """, data
+    )
+
     assert "a=select " == fill_sql_template("a=select ", data)
-    
+
     # try single quotes for finding json patterns
     assert "a=select * from b like '{%'" == fill_sql_template(
         "a=select * from b like '{%'", data
@@ -53,31 +57,29 @@ def test_fill_sql_template():
 
 
 def test_fill_sql_template_array():
-    data = {"a": [0,1,2]}
-    assert (
-        """select * from tbl where a in ('0','1','2')""" 
-        == fill_sql_template(
+    data = {"a": [0, 1, 2]}
+    assert """select * from tbl where a in ('0','1','2')""" == fill_sql_template(
         """select * from tbl where a in (
             {%- for i in a -%}
                 {%- if loop.index0 < loop.length - 1 -%}'{{-i-}}',
                 {%- else -%}'{{-i-}}'
                 {%- endif -%}
             {%- endfor -%}
-            )""", data)
+            )""",
+        data,
     )
 
     def upper(word):
         return word.upper()
 
-    data = {"a": ['a','b','c']}
-    assert (
-        """select * from tbl where a in ('A','B','C')""" 
-        == fill_sql_template(
+    data = {"a": ["a", "b", "c"]}
+    assert """select * from tbl where a in ('A','B','C')""" == fill_sql_template(
         """select * from tbl where a in (
             {%- for i in a -%}
                 {%- if loop.index0 < loop.length - 1 -%}'{{-i|upper-}}',
                 {%- else -%}'{{-i|upper-}}'
                 {%- endif -%}
             {%- endfor -%}
-            )""", data)
+            )""",
+        data,
     )


### PR DESCRIPTION
If string is registered as a raw datatype (for example it can represent a hive table name), then jinja template is broken because `fsql` identifies string as a dataframe and will not fill the template.

So for this edge case (conflicting case), we also treat primitive types as non-dataframe types.