### PR TITLE
Updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ df = transform(df,
             )
 df.show()
 ```
-```
+```rst
 +---+------+
 | id| value|
 +---+------+

--- a/README.md
+++ b/README.md
@@ -9,17 +9,27 @@
 
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://join.slack.com/t/fugue-project/shared_invite/zt-jl0pcahu-KdlSOgi~fP50TZWmNxdWYQ)
 
-**Fugue is an abstraction layer that helps big data practitioners accelerate development, decrease costs, and simplify maintenance of their projects.**
+**Fugue is an abstraction layer that helps big data practitioners accelerate development, decrease costs, and simplify maintenance of their big data projects.** This is done by allowing users to port Python, pandas, and SQL code to Spark and Dask easily, making it simpler to leverage distributed computing.
+
+Fugue is meant for:
+
+* Data scientists/analysts that want to **focus on defining logic rather than worrying about execution**
+* Data scientists transitioning **from pandas to Spark or Dask**
+* Big data practitioners finding **testing code** to be costly and slow
+* Data teams with big data projects that **struggle maintaining code**
+* SQL-lovers wanting to use **SQL to definee end-to-end workflows** in pandas, Spark, and Dask
 
 
--   **Framework-agnostic code**: Write code once in native Python or SQL, then port it to Pandas, Dask or Spark with minimal changes. Logic and execution are decoupled through Fugue, enabling users to leverage the Spark and Dask engines without learning the specific framework syntax.
+## Some Features
+
+-   **Cross-framework code**: Write code once in native Python or SQL, then port it to pandas, Dask or Spark with no changes. Logic and execution are decoupled through Fugue, enabling users to leverage the Spark and Dask engines without learning the specific framework syntax.
 -   **Rapid iterations for big data projects**: Test code on smaller data, then reliably scale to Dask or Spark when ready. This accelerates project iteration time and reduces expensive mistakes.
--   **Friendlier interface for Spark**: Users can get Python/Pandas code running on Spark with significanly less effort. FugueSQL extends SparkSQL to be a more complete programming language.
+-   **Friendlier interface for Spark**: Users can get Python/pandas code running on Spark with significanly less effort. FugueSQL extends SparkSQL to be a more complete programming language.
 -   **Highly testable code**: Fugue naturally makes logic more testable because the code will be written in native Python. Unit tests scale seamlessly from local workflows to distributed computing workflows.
 
 ## Fugue Transform
 
-The simplest way to use Fugue is the `transform` function. This lets users bring a parallelize the execution of a single function by bringing it to Spark or Dask. In the example below, the `map_letter_to_food` function takes in a mapping and replaces the values in a column with the mapped value. This is just pandas and Python so far (without Fugue).
+The simplest way to use Fugue is the `transform` function. This lets users bring a parallelize the execution of a single function by bringing it to Spark or Dask. In the example below, the `map_letter_to_food` function takes in a mapping and applies it on a column. This is just pandas and Python so far (without Fugue).
 
 ```python
 import pandas as pd
@@ -33,14 +43,14 @@ def map_letter_to_food(df: pd.DataFrame, mapping: Dict[str, str]) -> pd.DataFram
     return df
 ```
 
-Now, the `map_letter_to_food` function is used on the Spark execution engine by simply invoking the `transform` function of Fugue. The output `schema`, params` and `engine` are passed to the `transform` call. The `schema` is needed because it's a requirement on Spark.
+Now, the `map_letter_to_food` function is used on the Spark execution engine by simply invoking the `transform` function of Fugue. The output `schema`, `params` and `engine` are passed to the `transform` call. The `schema` is needed because it's a requirement on Spark.
 
 ```python
 from fugue import transform
 from fugue_spark import SparkExecutionEngine
 
 df = transform(df, 
-               map_to_food, 
+               map_letter_to_food, 
                schema="*",
                params=dict(mapping=map_dict),
                engine=SparkExecutionEngine
@@ -49,7 +59,7 @@ df.show()
 ```
 ```
 +---+------+
-| id|  food|
+| id| value|
 +---+------+
 |  0| Apple|
 |  1|Banana|
@@ -59,27 +69,28 @@ df.show()
 
 This syntax is simpler, cleaner, and more maintainable than the Spark equivalent. At the same time, no edits were made to the original pandas-based function to bring it to Spark. It is still usable on pandas DataFrames. Because the Spark execution engine was used, the returned `df` is now a Spark DataFrame. Fugue `transform` also supports `DaskExecutionEngine` and the pandas-based `NativeExecutionEngine`.
 
-## [Fugue SQL](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/fugue_sql/)
+## [FugueSQL](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/fugue_sql/)
 
 A SQL-based language capable of expressing end-to-end workflows. The `map_letter_to_food` function above is used in the SQL query below. This is how to use a Python-defined transformer along with the standard SQL `SELECT` statement.
 
 ```python
+from fugue_sql import fsql
+import json
+
 fsql("""
-    SELECT id, date, value FROM df
-    TRANSFORM USING map_letter_to_food (mapping=map_dict)
+    SELECT id, value FROM df
+    TRANSFORM USING map_letter_to_food (mapping="""+ json.dumps(map_dict) + """)
     PRINT
     """).run()
 ```
 
-For Fugue SQL, we can change the engine by passing it to the `run` method: `fsql(query).run("spark")`.
+For FugueSQL, we can change the engine by passing it to the `run` method: `fsql(query).run("spark")`.
 
 ## Jupyter Notebook Extension
 
-There is an accompanying notebook extension for Fugue SQL that lets users use the `%%fsql` cell magic. The extension also provides syntax highlighting for Fugue SQL cells. (Syntax highlighting is not available yet for JupyterLab).
+There is an accompanying notebook extension for FugueSQL that lets users use the `%%fsql` cell magic. The extension also provides syntax highlighting for FugueSQL cells. (Syntax highlighting is not available yet for JupyterLab).
 
-![Fugue SQL gif](https://miro.medium.com/max/700/1*6091-RcrOPyifJTLjo0anA.gif)
-
-**Loading extension in a notebook**
+![FugueSQL gif](https://miro.medium.com/max/700/1*6091-RcrOPyifJTLjo0anA.gif)
 
 The notebook environment can be setup by using the `setup` function as follows in the first cell of a notebook:
 
@@ -102,7 +113,7 @@ pip install fugue
 
 It also has the fullowing extras:
 
--   **sql**: to support [Fugue SQL](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/fugue_sql/index.md.html)
+-   **sql**: to support [FugueSQL](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/fugue_sql/index.md.html)
 -   **spark**: to support Spark as the [ExecutionEngine](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/advanced/execution_engine.html)
 -   **dask**: to support Dask as the [ExecutionEngine](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/advanced/execution_engine.html)
 -   **all**: install everything above
@@ -145,11 +156,25 @@ For the API docs, [click here](https://fugue.readthedocs.org)
 
 ## Further Resources
 
-View our latest presentations and content
+View some of our latest conferences presentations and content. For more, check the [Resources](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/resources.html) page in the tutorials.
 
--   [Tutorials](https://fugue-tutorials.readthedocs.io/en/latest/)
--   [Interoperable Python and SQL blog](https://towardsdatascience.com/interoperable-python-and-sql-in-jupyter-notebooks-86245e711352)
--   [Data Science Cross-Framework Library Blog](https://towardsdatascience.com/creating-pandas-and-spark-compatible-functions-with-fugue-8617c0b3d3a8)
+### Blogs
+
+James Le
+-   [Fugue: Reducing Spark Developer Friction](https://jameskle.com/writes/fugue)
+
+Coiled
+-   [Data Analysis with FugueSQL on Coiled Dask Clusters](https://coiled.io/blog/data-analysis-with-fuguesql-on-coiled-dask-clusters/)
+
+Towards Data Science
+-   [Interoperable Python and SQL in Jupyter Notebooks](https://towardsdatascience.com/interoperable-python-and-sql-in-jupyter-notebooks-86245e711352)
+-   [Using Pandera on Spark for Data Validation through Fugue](https://towardsdatascience.com/using-pandera-on-spark-for-data-validation-through-fugue-72956f274793)
+
+### Conferences
+
+-   [Spark Summit 2020 - Fugue: Unifying Spark and Non-Spark Ecosystems for Big Data Analytics](https://www.youtube.com/watch?v=BBd4b2pMk0c&t=2s)
+-   [PyCon US 2021 - Large Scale Data Validation with Spark and Dask](https://www.youtube.com/watch?v=2AdvBgjO_3Q)
+-   [Dask Summit 2021 - Dask SQL Query Engines](https://www.youtube.com/watch?v=bQDN41Bc3bw)
 
 ## Community and Contributing
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ import json
 
 fsql("""
     SELECT id, value FROM df
-    TRANSFORM USING map_letter_to_food (mapping="""+ json.dumps(map_dict) + """)
+    TRANSFORM USING map_letter_to_food(mapping="""+ json.dumps(map_dict) + """) SCHEMA *
     PRINT
     """).run()
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## Fugue Transform
 
-The simplest way to use Fugue is the `transform` function. This lets users bring a parallelize the execution of a single function by bringing it to Spark or Dask. In the example below, the `map_to_food` function takes in a mapping and replaces the values in a column with the mapped value. This is all pandas.
+The simplest way to use Fugue is the `transform` function. This lets users bring a parallelize the execution of a single function by bringing it to Spark or Dask. In the example below, the `map_letter_to_food` function takes in a mapping and replaces the values in a column with the mapped value. This is just pandas and Python so far (without Fugue).
 
 ```python
 import pandas as pd
@@ -57,20 +57,11 @@ df.show()
 +---+------+
 ```
 
-This syntax is simpler, cleaner, and more maintainable than the Spark equivalent. At the same time, no edits were made to the original pandas-based function to bring it to Spark. Because the Spark execution engine was used, the returned `df` is now a Spark DataFrame. Fugue `transform` also supports `DaskExecutionEngine` and the pandas-based `NativeExecutionEngine`.
+This syntax is simpler, cleaner, and more maintainable than the Spark equivalent. At the same time, no edits were made to the original pandas-based function to bring it to Spark. It is still usable on pandas DataFrames. Because the Spark execution engine was used, the returned `df` is now a Spark DataFrame. Fugue `transform` also supports `DaskExecutionEngine` and the pandas-based `NativeExecutionEngine`.
 
-## Getting Started
+## [Fugue SQL](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/fugue_sql/)
 
-View our latest presentations and content
-
--   [Tutorials](https://fugue-tutorials.readthedocs.io/en/latest/)
--   [Interoperable Python and SQL blog](https://towardsdatascience.com/interoperable-python-and-sql-in-jupyter-notebooks-86245e711352)
--   [Data Science Cross-Framework Library Blog](https://towardsdatascience.com/creating-pandas-and-spark-compatible-functions-with-fugue-8617c0b3d3a8)
-
-
-### [Fugue SQL](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/fugue_sql/index.md.html)
-
-A SQL-based language capable of expressing end-to-end workflows. The `map_latter_to_food` function above is used in the SQL query below. This is how to use a Python-defined transformer along with the standard SQL `SELECT` statement.
+A SQL-based language capable of expressing end-to-end workflows. The `map_letter_to_food` function above is used in the SQL query below. This is how to use a Python-defined transformer along with the standard SQL `SELECT` statement.
 
 ```python
 fsql("""
@@ -81,6 +72,25 @@ fsql("""
 ```
 
 For Fugue SQL, we can change the engine by passing it to the `run` method: `fsql(query).run("spark")`.
+
+## Jupyter Notebook Extension
+
+There is an accompanying notebook extension for Fugue SQL that lets users use the `%%fsql` cell magic. The extension also provides syntax highlighting for Fugue SQL cells. (Syntax highlighting is not available yet for JupyterLab).
+
+![Fugue SQL gif](https://miro.medium.com/max/700/1*6091-RcrOPyifJTLjo0anA.gif)
+
+**Loading extension in a notebook**
+
+The notebook environment can be setup by using the `setup` function as follows in the first cell of a notebook:
+
+```python
+from fugue_notebook import setup
+setup()
+```
+
+Note that you can automatically load `fugue_notebook` iPython extension at startup,
+read [this](https://ipython.readthedocs.io/en/stable/config/extensions/#using-extensions) to configure your Jupyter environment.
+
 
 ## Installation
 
@@ -103,57 +113,17 @@ For example a common use case is:
 pip install fugue[sql,spark]
 ```
 
-## Jupyter Notebook Extension
-
-There is an accompanying notebook extension for Fugue SQL that lets users use the `%%fsql` cell magic. The extension also provides syntax highlighting for Fugue SQL cells. (Syntax highlighting is not available yet for JupyterLab).
-
-![Fugue SQL gif](https://miro.medium.com/max/700/1*6091-RcrOPyifJTLjo0anA.gif)
-
-### Installating Notebook Extension
-
-To install the notebook extension:
+To install the notebook extension (after installing Fugue):
 
 ```bash
-pip install fugue
 jupyter nbextension install --py fugue_notebook
 jupyter nbextension enable fugue_notebook --py
 ```
 
-### Loading in a notebook
 
-The notebook environment can be setup by using the `setup` function as follows in the first cell of a notebook:
+## Tutorials
 
-```python
-from fugue_notebook import setup
-setup()
-```
-
-Note that you can automatically load `fugue_notebook` iPython extension at startup,
-read [this](https://ipython.readthedocs.io/en/stable/config/extensions/#using-extensions) to configure your Jupyter environment.
-
-### Usage
-
-To use Fugue SQL in a notebook, simply invoke the `%%fsql` cell magic.
-
-```bash
-%%fsql
-CREATE [[0]] SCHEMA a:int
-PRINT
-```
-
-To use Spark or Dask as an execution engine, specify it after `%%fsql`
-
-```bash
-%%fsql dask
-CREATE [[0]] SCHEMA a:int
-PRINT
-```
-
-## Get started
-
-The best way to start is to go through the [tutorials](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/index.html). We have the tutorials in an interactive notebook environent.
-
-For the API docs, [click here](https://fugue.readthedocs.org)
+The best way to start is to go through the [tutorials](https://fugue-tutorials.readthedocs.io/en/latest/). The tutorials can be run in an interactive notebook environment through binder or Docker:
 
 ### Run the tutorial using binder:
 
@@ -171,6 +141,16 @@ Alternatively, you should get decent performance if running its Docker image on 
 docker run -p 8888:8888 fugueproject/tutorials:latest
 ```
 
-## Contributing
+For the API docs, [click here](https://fugue.readthedocs.org)
+
+## Further Resources
+
+View our latest presentations and content
+
+-   [Tutorials](https://fugue-tutorials.readthedocs.io/en/latest/)
+-   [Interoperable Python and SQL blog](https://towardsdatascience.com/interoperable-python-and-sql-in-jupyter-notebooks-86245e711352)
+-   [Data Science Cross-Framework Library Blog](https://towardsdatascience.com/creating-pandas-and-spark-compatible-functions-with-fugue-8617c0b3d3a8)
+
+## Community and Contributing
 
 Feel free to message us on [Slack](https://join.slack.com/t/fugue-project/shared_invite/zt-jl0pcahu-KdlSOgi~fP50TZWmNxdWYQ). We also have [contributing instructions](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://join.slack.com/t/fugue-project/shared_invite/zt-jl0pcahu-KdlSOgi~fP50TZWmNxdWYQ)
 
-**Fugue is an abstraction layer that helps big data practitioners accelerate development, decrease costs, and simplify maintenance of their big data projects.** This is done by allowing users to port Python, pandas, and SQL code to Spark and Dask easily, making it easy to leverage distributed computing.
+**Fugue is an abstraction layer that helps big data practitioners accelerate development, decrease costs, and simplify maintenance of their big data projects.** This is done by allowing users to port Python, pandas, and SQL code to Spark and Dask with minimal changes, making it easy to leverage distributed computing.
 
 Fugue is meant for:
 
@@ -42,7 +42,7 @@ def map_letter_to_food(df: pd.DataFrame, mapping: Dict[str, str]) -> pd.DataFram
     return df
 ```
 
-Now, the `map_letter_to_food` function is brought to the Spark execution engine by simply invoking the `transform` function of Fugue. The output `schema`, `params` and `engine` are passed to the `transform` call. The `schema` is needed because it's a requirement on Spark. "*" means all input columns are in the output.
+Now, the `map_letter_to_food` function is brought to the Spark execution engine by simply invoking the `transform` function of Fugue. The output `schema`, `params` and `engine` are passed to the `transform` call. The `schema` is needed because it's a requirement on Spark. A schema of "*" below means all input columns are in the output.
 
 ```python
 from fugue import transform

--- a/README.md
+++ b/README.md
@@ -13,19 +13,18 @@
 
 Fugue is meant for:
 
-* Data scientists/analysts that want to **focus on defining logic rather than worrying about execution**
-* SQL-lovers wanting to use **SQL to define end-to-end workflows** in pandas, Spark, and Dask
-* Data scientists using pandas wanting to take advatange of **Spark or Dask** with minimal effort
-* Big data practitioners finding **testing code** to be costly and slow
-* Data teams with big data projects that **struggle maintaining code**
-
+*   Data scientists/analysts that want to **focus on defining logic rather than worrying about execution**
+*   SQL-lovers wanting to use **SQL to define end-to-end workflows** in pandas, Spark, and Dask
+*   Data scientists using pandas wanting to take advatange of **Spark or Dask** with minimal effort
+*   Big data practitioners finding **testing code** to be costly and slow
+*   Data teams with big data projects that **struggle maintaining code**
 
 ## Select Features
 
--   **Cross-framework code**: Write code once in native Python or SQL, then port it to pandas, Dask or Spark with no changes. Logic and execution are decoupled through Fugue, enabling users to leverage the Spark and Dask engines without learning the specific framework syntax.
--   **Rapid iterations for big data projects**: Test code on smaller data, then reliably scale to Dask or Spark when ready. This accelerates project iteration time and reduces expensive mistakes.
--   **Friendlier interface for Spark**: Users can get Python/pandas code running on Spark with significanly less effort. FugueSQL extends SparkSQL to be a more complete programming language.
--   **Highly testable code**: Fugue naturally makes logic more testable because the code will be written in native Python. Unit tests scale seamlessly from local workflows to distributed computing workflows.
+*   **Cross-framework code**: Write code once in native Python or SQL, then port it to pandas, Dask or Spark with no changes. Logic and execution are decoupled through Fugue, enabling users to leverage the Spark and Dask engines without learning the specific framework syntax.
+*   **Rapid iterations for big data projects**: Test code on smaller data, then reliably scale to Dask or Spark when ready. This accelerates project iteration time and reduces expensive mistakes.
+*   **Friendlier interface for Spark**: Users can get Python/pandas code running on Spark with significanly less effort. FugueSQL extends SparkSQL to be a more complete programming language.
+*   **Highly testable code**: Fugue naturally makes logic more testable because the code will be written in native Python. Unit tests scale seamlessly from local workflows to distributed computing workflows.
 
 ## Fugue Transform
 
@@ -113,10 +112,10 @@ pip install fugue
 
 It also has the following extras:
 
--   **sql**: to support [FugueSQL](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/fugue_sql/)
--   **spark**: to support Spark as the [ExecutionEngine](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/advanced/execution_engine.html)
--   **dask**: to support Dask as the [ExecutionEngine](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/advanced/execution_engine.html)
--   **all**: install everything above
+*   **sql**: to support [FugueSQL](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/fugue_sql/)
+*   **spark**: to support Spark as the [ExecutionEngine](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/advanced/execution_engine.html)
+*   **dask**: to support Dask as the [ExecutionEngine](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/advanced/execution_engine.html)
+*   **all**: install everything above
 
 For example a common use case is:
 
@@ -131,20 +130,19 @@ jupyter nbextension install --py fugue_notebook
 jupyter nbextension enable fugue_notebook --py
 ```
 
-
 ## [Tutorials](https://fugue-tutorials.readthedocs.io/en/latest/)
 
 The best way to start is to go through the [tutorials](https://fugue-tutorials.readthedocs.io/en/latest/).
 
 The tutorials can also be run in an interactive notebook environment through binder or Docker:
 
-**Using binder:**
+### Using binder
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fugue-project/tutorials/master)
 
 **Note it runs slow on binder** because the machine on binder isn't powerful enough for a distributed framework such as Spark. Parallel executions can become sequential, so some of the performance comparison examples will not give you the correct numbers.
 
-**Using Docker**
+### Using Docker
 
 Alternatively, you should get decent performance if running its Docker image on your own machine:
 
@@ -161,20 +159,20 @@ View some of our latest conferences presentations and content. For more, check t
 ### Blogs
 
 James Le
--   [Fugue: Reducing Spark Developer Friction](https://jameskle.com/writes/fugue)
+*   [Fugue: Reducing Spark Developer Friction](https://jameskle.com/writes/fugue)
 
 Coiled
--   [Data Analysis with FugueSQL on Coiled Dask Clusters](https://coiled.io/blog/data-analysis-with-fuguesql-on-coiled-dask-clusters/)
+*   [Data Analysis with FugueSQL on Coiled Dask Clusters](https://coiled.io/blog/data-analysis-with-fuguesql-on-coiled-dask-clusters/)
 
 Towards Data Science
--   [Interoperable Python and SQL in Jupyter Notebooks](https://towardsdatascience.com/interoperable-python-and-sql-in-jupyter-notebooks-86245e711352)
--   [Using Pandera on Spark for Data Validation through Fugue](https://towardsdatascience.com/using-pandera-on-spark-for-data-validation-through-fugue-72956f274793)
+*   [Interoperable Python and SQL in Jupyter Notebooks](https://towardsdatascience.com/interoperable-python-and-sql-in-jupyter-notebooks-86245e711352)
+*   [Using Pandera on Spark for Data Validation through Fugue](https://towardsdatascience.com/using-pandera-on-spark-for-data-validation-through-fugue-72956f274793)
 
 ### Conferences
 
--   [Spark Summit 2020 - Fugue: Unifying Spark and Non-Spark Ecosystems for Big Data Analytics](https://www.youtube.com/watch?v=BBd4b2pMk0c&t=2s)
--   [PyCon US 2021 - Large Scale Data Validation with Spark and Dask](https://www.youtube.com/watch?v=2AdvBgjO_3Q)
--   [Dask Summit 2021 - Dask SQL Query Engines](https://www.youtube.com/watch?v=bQDN41Bc3bw)
+*   [Spark Summit 2020 - Fugue: Unifying Spark and Non-Spark Ecosystems for Big Data Analytics](https://www.youtube.com/watch?v=BBd4b2pMk0c&t=2s)
+*   [PyCon US 2021 - Large Scale Data Validation with Spark and Dask](https://www.youtube.com/watch?v=2AdvBgjO_3Q)
+*   [Dask Summit 2021 - Dask SQL Query Engines](https://www.youtube.com/watch?v=bQDN41Bc3bw)
 
 ## Community and Contributing
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fugue is meant for:
 
 ## Fugue Transform
 
-The simplest way to use Fugue is the `transform` function. This lets users bring a parallelize the execution of a single function by bringing it to Spark or Dask. In the example below, the `map_letter_to_food` function takes in a mapping and applies it on a column. This is just pandas and Python so far (without Fugue).
+The simplest way to use Fugue is the [`transform` function](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/beginner/introduction.html?highlight=transform#Fugue-transform). This lets users bring a parallelize the execution of a single function by bringing it to Spark or Dask. In the example below, the `map_letter_to_food` function takes in a mapping and applies it on a column. This is just pandas and Python so far (without Fugue).
 
 ```python
 import pandas as pd
@@ -79,9 +79,9 @@ import json
 
 fsql("""
     SELECT id, value FROM df
-    TRANSFORM USING map_letter_to_food(mapping="""+ json.dumps(map_dict) + """) SCHEMA *
+    TRANSFORM USING map_letter_to_food(mapping={{mapping}}) SCHEMA *
     PRINT
-    """).run()
+    """,mapping=json.dumps(map_dict)).run()
 ```
 
 For FugueSQL, we can change the engine by passing it to the `run` method: `fsql(query).run("spark")`.

--- a/README.md
+++ b/README.md
@@ -121,19 +121,19 @@ jupyter nbextension enable fugue_notebook --py
 ```
 
 
-## Tutorials
+## [Tutorials](https://fugue-tutorials.readthedocs.io/en/latest/)
 
-The best way to start is to go through the [tutorials](https://fugue-tutorials.readthedocs.io/en/latest/). The tutorials can be run in an interactive notebook environment through binder or Docker:
+The best way to start is to go through the [tutorials](https://fugue-tutorials.readthedocs.io/en/latest/). 
 
-### Run the tutorial using binder:
+The tutorials can also be run in an interactive notebook environment through binder or Docker:
+
+**Using binder:**
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fugue-project/tutorials/master)
 
-**But it runs slow on binder**, the machine on binder isn't powerful enough for
-a distributed framework such as Spark. Parallel executions can become sequential, so some of the
-performance comparison examples will not give you the correct numbers.
+**Note it runs slow on binder** because the machine on binder isn't powerful enough for a distributed framework such as Spark. Parallel executions can become sequential, so some of the performance comparison examples will not give you the correct numbers.
 
-### Run the tutorial using Docker
+**Using Docker**
 
 Alternatively, you should get decent performance if running its Docker image on your own machine:
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@
 
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://join.slack.com/t/fugue-project/shared_invite/zt-jl0pcahu-KdlSOgi~fP50TZWmNxdWYQ)
 
-**Fugue is an abstraction layer that helps big data practitioners accelerate development, decrease costs, and simplify maintenance of their big data projects.** This is done by allowing users to port Python, pandas, and SQL code to Spark and Dask easily, making it simpler to leverage distributed computing.
+**Fugue is an abstraction layer that helps big data practitioners accelerate development, decrease costs, and simplify maintenance of their big data projects.** This is done by allowing users to port Python, pandas, and SQL code to Spark and Dask easily, making it easy to leverage distributed computing.
 
 Fugue is meant for:
 
 * Data scientists/analysts that want to **focus on defining logic rather than worrying about execution**
-* Data scientists transitioning **from pandas to Spark or Dask**
+* SQL-lovers wanting to use **SQL to define end-to-end workflows** in pandas, Spark, and Dask
+* Data scientists using pandas wanting to take advatange of **Spark or Dask** with minimal effort
 * Big data practitioners finding **testing code** to be costly and slow
 * Data teams with big data projects that **struggle maintaining code**
-* SQL-lovers wanting to use **SQL to definee end-to-end workflows** in pandas, Spark, and Dask
 
 
-## Some Features
+## Select Features
 
 -   **Cross-framework code**: Write code once in native Python or SQL, then port it to pandas, Dask or Spark with no changes. Logic and execution are decoupled through Fugue, enabling users to leverage the Spark and Dask engines without learning the specific framework syntax.
 -   **Rapid iterations for big data projects**: Test code on smaller data, then reliably scale to Dask or Spark when ready. This accelerates project iteration time and reduces expensive mistakes.
@@ -43,14 +43,14 @@ def map_letter_to_food(df: pd.DataFrame, mapping: Dict[str, str]) -> pd.DataFram
     return df
 ```
 
-Now, the `map_letter_to_food` function is used on the Spark execution engine by simply invoking the `transform` function of Fugue. The output `schema`, `params` and `engine` are passed to the `transform` call. The `schema` is needed because it's a requirement on Spark.
+Now, the `map_letter_to_food` function is brought to the Spark execution engine by simply invoking the `transform` function of Fugue. The output `schema`, `params` and `engine` are passed to the `transform` call. The `schema` is needed because it's a requirement on Spark. "*" means all input columns are in the output.
 
 ```python
 from fugue import transform
 from fugue_spark import SparkExecutionEngine
 
-df = transform(df, 
-               map_letter_to_food, 
+df = transform(df,
+               map_letter_to_food,
                schema="*",
                params=dict(mapping=map_dict),
                engine=SparkExecutionEngine
@@ -71,7 +71,7 @@ This syntax is simpler, cleaner, and more maintainable than the Spark equivalent
 
 ## [FugueSQL](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/fugue_sql/)
 
-A SQL-based language capable of expressing end-to-end workflows. The `map_letter_to_food` function above is used in the SQL query below. This is how to use a Python-defined transformer along with the standard SQL `SELECT` statement.
+A SQL-based language capable of expressing end-to-end workflows. The `map_letter_to_food` function above is used in the SQL expression below. This is how to use a Python-defined transformer along with the standard SQL `SELECT` statement.
 
 ```python
 from fugue_sql import fsql
@@ -111,9 +111,9 @@ Fugue can be installed through pip by using:
 pip install fugue
 ```
 
-It also has the fullowing extras:
+It also has the following extras:
 
--   **sql**: to support [FugueSQL](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/fugue_sql/index.md.html)
+-   **sql**: to support [FugueSQL](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/fugue_sql/)
 -   **spark**: to support Spark as the [ExecutionEngine](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/advanced/execution_engine.html)
 -   **dask**: to support Dask as the [ExecutionEngine](https://fugue-tutorials.readthedocs.io/en/latest/tutorials/advanced/execution_engine.html)
 -   **all**: install everything above
@@ -134,7 +134,7 @@ jupyter nbextension enable fugue_notebook --py
 
 ## [Tutorials](https://fugue-tutorials.readthedocs.io/en/latest/)
 
-The best way to start is to go through the [tutorials](https://fugue-tutorials.readthedocs.io/en/latest/). 
+The best way to start is to go through the [tutorials](https://fugue-tutorials.readthedocs.io/en/latest/).
 
 The tutorials can also be run in an interactive notebook environment through binder or Docker:
 


### PR DESCRIPTION
Updating the README to be more direct about what Fugue is and what it does in 2 lines. The length of the previous README was also too long. A lot of this has been shortened. 

The `transform` function is also the first introduction to Fugue. 

The diff of this PR is bad. I suggest reading the README on my [fork](https://github.com/kvnkho/fugue)
