### PR TITLE
Include license file in source distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 description-file = README.md
+license_files = LICENSE
 
 [tool:pytest]
 addopts =


### PR DESCRIPTION
It would be helpful to include the license file in the source distribution. See:
https://packaging.python.org/guides/using-manifest-in/
https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file