### PR TITLE
Raise SchemaError on invalid pd.DataFrame col name

### DIFF
--- a/fugue/dataframe/pandas_dataframe.py
+++ b/fugue/dataframe/pandas_dataframe.py
@@ -9,6 +9,7 @@ from fugue.dataframe.dataframe import (
 )
 from fugue.exceptions import FugueDataFrameInitError, FugueDataFrameOperationError
 from triad.collections.schema import Schema
+from triad.collections.schema import SchemaError
 from triad.utils.assertion import assert_or_throw
 from triad.utils.pandas_like import PD_UTILS
 
@@ -75,6 +76,8 @@ class PandasDataFrame(LocalBoundedDataFrame):
                 pdf, schema = self._apply_schema(pdf, schema)
             super().__init__(schema, metadata)
             self._native = pdf
+        except SchemaError as e:
+            raise e
         except Exception as e:
             raise FugueDataFrameInitError from e
 

--- a/tests/fugue/dataframe/test_pandas_dataframe.py
+++ b/tests/fugue/dataframe/test_pandas_dataframe.py
@@ -62,6 +62,11 @@ def test_init():
     raises(FugueDataFrameInitError, lambda: PandasDataFrame(123))
 
 
+def test_init_raises_error_on_invalid_column_name():
+    pdf = pd.DataFrame({"valid": [0], "invalid( )": [1]})
+    raises(SchemaError, lambda: PandasDataFrame(pdf))
+
+
 def test_simple_methods():
     df = PandasDataFrame([], "a:str,b:int")
     assert df.as_pandas() is df.native

--- a/tests/fugue/dataframe/test_pandas_dataframe.py
+++ b/tests/fugue/dataframe/test_pandas_dataframe.py
@@ -62,7 +62,7 @@ def test_init():
     raises(FugueDataFrameInitError, lambda: PandasDataFrame(123))
 
 
-def test_init_raises_error_on_invalid_column_name():
+def test_init_raises_schemaerror_on_invalid_column_name():
     pdf = pd.DataFrame({"valid": [0], "invalid( )": [1]})
     raises(SchemaError, lambda: PandasDataFrame(pdf))
 


### PR DESCRIPTION
Previously only FugueDataFrameInitError was raised which doesnt inform
the user which column name is causing the issue

Closes #290 