### PR TITLE
Remove most FugueDataFrameInitError

### DIFF
--- a/fugue_test/dataframe_suite.py
+++ b/fugue_test/dataframe_suite.py
@@ -8,11 +8,7 @@ import numpy as np
 import pandas as pd
 from fugue.dataframe import ArrowDataFrame, DataFrame
 from fugue.dataframe.utils import _df_eq as df_eq
-from fugue.exceptions import (
-    FugueDataFrameEmptyError,
-    FugueDataFrameInitError,
-    FugueDataFrameOperationError,
-)
+from fugue.exceptions import FugueDataFrameEmptyError, FugueDataFrameOperationError
 from pytest import raises
 from triad.collections.schema import Schema
 
@@ -37,10 +33,10 @@ class DataFrameTests(object):
             raise NotImplementedError
 
         def test_init_basic(self):
-            raises(FugueDataFrameInitError, lambda: self.df())
-            raises(FugueDataFrameInitError, lambda: self.df([]))
-            raises(FugueDataFrameInitError, lambda: self.df([[]], Schema()))
-            raises(FugueDataFrameInitError, lambda: self.df([[1]], Schema()))
+            raises(Exception, lambda: self.df())
+            raises(Exception, lambda: self.df([]))
+            raises(Exception, lambda: self.df([[]], Schema()))
+            raises(Exception, lambda: self.df([[1]], Schema()))
             # raises(SchemaError, lambda: self.df([[1]]))  # schema can be inferred
 
             df = self.df([], "a:str,b:int")

--- a/tests/fugue/dataframe/test_array_dataframe.py
+++ b/tests/fugue/dataframe/test_array_dataframe.py
@@ -6,11 +6,9 @@ import numpy as np
 import pandas as pd
 from fugue.dataframe import ArrayDataFrame, PandasDataFrame
 from fugue.dataframe.utils import _df_eq as df_eq
-from fugue.exceptions import FugueDataFrameInitError
 from fugue_test.dataframe_suite import DataFrameTests
 from pytest import raises
-from triad.collections.schema import Schema, SchemaError
-from triad.exceptions import InvalidOperationError
+from triad.collections.schema import Schema
 
 
 class ArrayDataFrameTests(DataFrameTests.Tests):
@@ -62,7 +60,7 @@ def test_init():
     df = ArrayDataFrame([], "x:str,y:double")
     assert df.empty
 
-    raises(FugueDataFrameInitError, lambda: ArrayDataFrame(123))
+    raises(Exception, lambda: ArrayDataFrame(123))
 
 
 def test_simple_methods():

--- a/tests/fugue/dataframe/test_arrow_dataframe.py
+++ b/tests/fugue/dataframe/test_arrow_dataframe.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 from fugue.dataframe import ArrowDataFrame, PandasDataFrame
 from fugue.dataframe.utils import _df_eq as df_eq
-from fugue.exceptions import FugueDataFrameInitError
 from fugue_test.dataframe_suite import DataFrameTests
 from pytest import raises
 from triad.collections.schema import Schema, SchemaError
@@ -53,4 +52,4 @@ def test_init():
     assert df.is_local
     assert df.is_bounded
 
-    raises(FugueDataFrameInitError, lambda: ArrowDataFrame(123))
+    raises(Exception, lambda: ArrowDataFrame(123))

--- a/tests/fugue/dataframe/test_dataframe_iterable_dataframe.py
+++ b/tests/fugue/dataframe/test_dataframe_iterable_dataframe.py
@@ -11,7 +11,6 @@ from fugue.dataframe import (
     LocalDataFrameIterableDataFrame,
 )
 from fugue.dataframe.utils import _df_eq as df_eq
-from fugue.exceptions import FugueDataFrameInitError
 from fugue_test.dataframe_suite import DataFrameTests
 from pytest import raises
 from triad.collections.schema import Schema, SchemaError
@@ -36,7 +35,7 @@ class LocalDataFrameIterableDataFrameTests(DataFrameTests.Tests):
 
 
 def test_init():
-    raises(FugueDataFrameInitError, lambda: LocalDataFrameIterableDataFrame(1))
+    raises(Exception, lambda: LocalDataFrameIterableDataFrame(1))
 
     def get_dfs(seq):
         for x in seq:
@@ -47,10 +46,10 @@ def test_init():
             if x == "o":  # bad schema but empty dataframe doesn't matter
                 yield ArrayDataFrame([], "a:int,b:str")
 
-    with raises(FugueDataFrameInitError):
+    with raises(Exception):
         LocalDataFrameIterableDataFrame(get_dfs(""))
 
-    with raises(FugueDataFrameInitError):  # schema mismatch
+    with raises(Exception):  # schema mismatch
         LocalDataFrameIterableDataFrame(get_dfs("v"), "a:int,b:str")
 
     df = LocalDataFrameIterableDataFrame(get_dfs(""), "a:str")

--- a/tests/fugue/dataframe/test_iterable_dataframe.py
+++ b/tests/fugue/dataframe/test_iterable_dataframe.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 from fugue.dataframe import IterableDataFrame, PandasDataFrame
 from fugue.dataframe.utils import _df_eq as df_eq
-from fugue.exceptions import FugueDataFrameInitError
 from fugue_test.dataframe_suite import DataFrameTests
 from pytest import raises
 from triad.collections.schema import Schema, SchemaError
@@ -65,7 +64,7 @@ def test_init():
     assert df.empty
     assert df.is_local
 
-    raises(FugueDataFrameInitError, lambda: IterableDataFrame(123))
+    raises(Exception, lambda: IterableDataFrame(123))
 
 
 def test_simple_methods():

--- a/tests/fugue/dataframe/test_pandas_dataframe.py
+++ b/tests/fugue/dataframe/test_pandas_dataframe.py
@@ -8,7 +8,6 @@ import pandas as pd
 from fugue.dataframe import PandasDataFrame
 from fugue.dataframe.array_dataframe import ArrayDataFrame
 from fugue.dataframe.utils import _df_eq as df_eq
-from fugue.exceptions import FugueDataFrameInitError
 from fugue_test.dataframe_suite import DataFrameTests
 from pytest import raises
 from triad.collections.schema import Schema, SchemaError
@@ -29,7 +28,7 @@ def test_init():
     assert Schema(df.native) == "a:str,b:int"
 
     pdf = pd.DataFrame([["a", 1], ["b", 2]])
-    raises(FugueDataFrameInitError, lambda: PandasDataFrame(pdf))
+    raises(Exception, lambda: PandasDataFrame(pdf))
     df = PandasDataFrame(pdf, "a:str,b:str")
     assert [["a", "1"], ["b", "2"]] == df.native.values.tolist()
     df = PandasDataFrame(pdf, "a:str,b:int")
@@ -59,7 +58,7 @@ def test_init():
     df = PandasDataFrame([], "x:str,y:double")
     assert [] == df.native.values.tolist()
 
-    raises(FugueDataFrameInitError, lambda: PandasDataFrame(123))
+    raises(Exception, lambda: PandasDataFrame(123))
 
 
 def test_simple_methods():

--- a/tests/fugue_dask/test_dataframe.py
+++ b/tests/fugue_dask/test_dataframe.py
@@ -9,7 +9,6 @@ import pandas
 from fugue.dataframe.array_dataframe import ArrayDataFrame
 from fugue.dataframe.pandas_dataframe import PandasDataFrame
 from fugue.dataframe.utils import _df_eq as df_eq
-from fugue.exceptions import FugueDataFrameInitError
 from fugue_dask.dataframe import DaskDataFrame
 from fugue_test.dataframe_suite import DataFrameTests
 from pytest import raises
@@ -30,7 +29,7 @@ def test_init():
     assert df.schema == "a:str,b:int"
 
     pdf = pandas.DataFrame([["a", 1], ["b", 2]])
-    raises(FugueDataFrameInitError, lambda: DaskDataFrame(pdf))
+    raises(Exception, lambda: DaskDataFrame(pdf))
     df = DaskDataFrame(pdf, "a:str,b:str")
     assert [["a", "1"], ["b", "2"]] == df.as_pandas().values.tolist()
     df = DaskDataFrame(pdf, "a:str,b:int")
@@ -60,7 +59,7 @@ def test_init():
     df = DaskDataFrame([], "x:str,y:double")
     assert [] == df.as_pandas().values.tolist()
 
-    raises(FugueDataFrameInitError, lambda: DaskDataFrame(123))
+    raises(Exception, lambda: DaskDataFrame(123))
 
 
 def test_simple_methods():

--- a/tests/fugue_duckdb/test_dataframe.py
+++ b/tests/fugue_duckdb/test_dataframe.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 from fugue import ArrowDataFrame
 from fugue.dataframe.utils import _df_eq as df_eq
-from fugue.exceptions import FugueDataFrameInitError
 from fugue_test.dataframe_suite import DataFrameTests
 from pytest import raises
 

--- a/tests/fugue_spark/test_dataframe.py
+++ b/tests/fugue_spark/test_dataframe.py
@@ -9,7 +9,6 @@ from fugue.dataframe.array_dataframe import ArrayDataFrame
 from fugue.dataframe.pandas_dataframe import PandasDataFrame
 from fugue.dataframe.utils import _df_eq as df_eq
 from fugue.dataframe.utils import to_local_bounded_df
-from fugue.exceptions import FugueDataFrameInitError
 from fugue_test.dataframe_suite import DataFrameTests
 from pyspark.sql import SparkSession
 from pytest import raises

--- a/tests/fugue_spark/utils/test_io.py
+++ b/tests/fugue_spark/utils/test_io.py
@@ -3,7 +3,6 @@ import os
 from fugue.collections.partition import PartitionSpec
 from fugue.dataframe.pandas_dataframe import PandasDataFrame
 from fugue.dataframe.utils import _df_eq as df_eq
-from fugue.exceptions import FugueDataFrameInitError
 from fugue_spark.dataframe import SparkDataFrame
 from fugue_spark._utils.convert import to_schema, to_spark_schema
 from fugue_spark._utils.io import SparkIO


### PR DESCRIPTION
It hides the real errors, and not very useful.

After this major change, https://github.com/fugue-project/fugue/issues/277, we can make exceptions more explicit, the traceback will be pruned by Fugue.