### PR TITLE
Upgrading black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       hooks:
         - id: pylint
     - repo: https://github.com/ambv/black
-      rev: 20.8b1
+      rev: v22.3.0
       hooks:
       - id: black
         types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       hooks:
         - id: pylint
     - repo: https://github.com/ambv/black
-      rev: v22.3.0
+      rev: 22.3.0
       hooks:
       - id: black
         types: [python]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ qpd[dask]
 
 # test requirements
 pre-commit
-black
+black>=22.3.0
 mypy
 flake8
 autopep8


### PR DESCRIPTION
Our linter in Github Actions is failing due to the version of `click`. This has been fixed in the latest version `black` so this PR pins the versions in requirements.txt and in the `pre-commit` configuration.

Related to issue #313 