### PR TITLE
Remove duckdb version cap

### DIFF
--- a/fugue_duckdb/dask.py
+++ b/fugue_duckdb/dask.py
@@ -1,5 +1,7 @@
-from typing import Any, Optional, Union, Callable
+from typing import Any, Callable, Optional, Union
 
+import duckdb
+import pyarrow as pa
 from duckdb import DuckDBPyConnection
 from fugue import DataFrame, LocalDataFrame, PartitionCursor, PartitionSpec
 from fugue.collections.partition import EMPTY_PARTITION_SPEC
@@ -9,7 +11,6 @@ from triad import assert_or_throw
 import dask.dataframe as dd
 from fugue_duckdb.dataframe import DuckDataFrame
 from fugue_duckdb.execution_engine import DuckExecutionEngine
-import pyarrow as pa
 
 
 class DuckDaskExecutionEngine(DuckExecutionEngine):
@@ -37,7 +38,7 @@ class DuckDaskExecutionEngine(DuckExecutionEngine):
                 )
             else:
                 return DuckDataFrame(
-                    self.connection.from_arrow_table(ddf.as_arrow()),
+                    duckdb.arrow(ddf.as_arrow(), connection=self.connection),
                     metadata=dict(ddf.metadata),
                 )
         return super().to_df(df, schema, metadata)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
             "jupyterlab",
             "ipython>=7.10.0",
             "dash",
-            "duckdb>=0.3.1,<0.3.3",
+            "duckdb>=0.3.2",
             "pyarrow>=5.0.0",
             "ibis-framework>=2; python_version >= '3.7'",
         ],
@@ -77,10 +77,10 @@ setup(
     package_data={"fugue_notebook": ["nbextension/*"]},
     entry_points={
         "fugue.plugins": [
-            "ibis = fugue_ibis:register",
-            "duckdb = fugue_duckdb:register",
-            "spark = fugue_spark:register",
-            "dask = fugue_dask:register",
+            "ibis = fugue_ibis:register[ibis]",
+            "duckdb = fugue_duckdb:register[duckdb]",
+            "spark = fugue_spark:register[spark]",
+            "dask = fugue_dask:register[dask]",
         ]
     },
 )

--- a/tests/fugue_duckdb/test_dataframe.py
+++ b/tests/fugue_duckdb/test_dataframe.py
@@ -21,7 +21,7 @@ class DuckDataFrameTests(DataFrameTests.Tests):
         self, data: Any = None, schema: Any = None, metadata: Any = None
     ) -> DuckDataFrame:
         df = ArrowDataFrame(data, schema, metadata)
-        return DuckDataFrame(self._con.from_arrow_table(df.native), metadata=metadata)
+        return DuckDataFrame(duckdb.arrow(df.native, self._con), metadata=metadata)
 
     def test_as_array_special_values(self):
         for func in [

--- a/tests/fugue_duckdb/test_utils.py
+++ b/tests/fugue_duckdb/test_utils.py
@@ -41,9 +41,7 @@ def test_type_conversion():
     con = duckdb.connect()
 
     def assert_(tp):
-        dt = con.from_arrow_table(pa.Table.from_pydict(dict(a=pa.nulls(2, tp)))).types[
-            0
-        ]
+        dt = duckdb.arrow(pa.Table.from_pydict(dict(a=pa.nulls(2, tp))), con).types[0]
         assert to_pa_type(dt) == tp
         dt = to_duck_type(tp)
         assert to_pa_type(dt) == tp
@@ -68,6 +66,22 @@ def test_type_conversion():
     assert_(pa.list_(pa.struct([pa.field("x", pa.int64())])))
     assert_(
         pa.struct([pa.field("x", pa.int64()), pa.field("yy", pa.list_(pa.int64()))])
+    )
+    assert_(
+        pa.struct(
+            [
+                pa.field("x", pa.int64()),
+                pa.field("yy", pa.struct([pa.field("x", pa.int64())])),
+            ]
+        )
+    )
+    assert_(
+        pa.struct(
+            [
+                pa.field("x", pa.int64()),
+                pa.field("yy", pa.list_(pa.struct([pa.field("x", pa.int64())]))),
+            ]
+        )
     )
 
     raises(ValueError, lambda: to_pa_type(""))


### PR DESCRIPTION
We will temporarily keep the support of duckdb 0.3.2 because a lot of Fugue 0.6.6 users will still be using this version.