### PR TITLE
Register whylogs extension

### DIFF
--- a/fugue_contrib/contrib.py
+++ b/fugue_contrib/contrib.py
@@ -3,4 +3,5 @@ from typing import Dict, Any
 FUGUE_CONTRIB: Dict[str, Any] = {
     "viz": {"module": "fugue_contrib.viz"},
     "sns": {"module": "fugue_contrib.seaborn"},
+    "why": {"module": "whylogs.api.fugue.registry"},
 }


### PR DESCRIPTION
Add a line to register a whylogs extension for WhyViz which defines a fugue Outputter:
see: https://github.com/whylabs/whylogs/blob/mainline/python/whylogs/api/fugue/registry.py