### PR TITLE
Idiomatic polars `peek_dict` method

### DIFF
--- a/fugue_polars/polars_dataframe.py
+++ b/fugue_polars/polars_dataframe.py
@@ -75,7 +75,7 @@ class PolarsDataFrame(LocalBoundedDataFrame):
 
     def peek_dict(self) -> Dict[str, Any]:
         self.assert_not_empty()
-        return dict(zip(self._native.columns, self._native.row(0)))
+        return self._native.row(0, named=True)
 
     def count(self) -> int:
         return self.native.shape[0]


### PR DESCRIPTION
Extremely minor tweak for more idiomatic Polars `peek_dict`.
(We have a "named" param on the row[^1] method for this).

[^1]: https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/api/polars.DataFrame.row.html