### PR TITLE
importing parse_execution_engine

### DIFF
--- a/fugue/__init__.py
+++ b/fugue/__init__.py
@@ -48,6 +48,7 @@ from fugue.execution.factory import (
     register_default_sql_engine,
     register_execution_engine,
     register_sql_engine,
+    parse_execution_engine
 )
 from fugue.execution.native_execution_engine import (
     NativeExecutionEngine,


### PR DESCRIPTION
importing `parse_execution_engine` otherwise [prefect-fugue](https://github.com/fugue-project/prefect-fugue) doesnt work

![image](https://github.com/fugue-project/fugue/assets/23236957/5b1498e5-7626-4a97-8add-a9ed9e17f742)

![image](https://github.com/fugue-project/fugue/assets/23236957/b0da8ddc-8894-4805-8b68-9528b8a908dd)
