### PR TITLE
Fix dependency: Python 3.11.9 breaks Dask

### DIFF
--- a/.github/workflows/test_dask.yml
+++ b/.github/workflows/test_dask.yml
@@ -20,33 +20,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test_dask_lower_bound:
-    name: Dask 2023.5.0
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: make devenv
-    - name: Setup Dask
-      run: pip install pyarrow==7.0.0 pandas==2.0.2 dask[dataframe,distributed]==2023.5.0
-    - name: Test
-      run: make testdask
 
   test_dask_latest:
     name: Dask Latest
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: make devenv
     - name: Setup Dask

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "cpp_sql_parser": ["fugue-sql-antlr[cpp]>=0.2.0"],
         "spark": ["pyspark>=3.1.1"],
         "dask": [
-            "dask[distributed,dataframe]>=2023.5.0",
+            "dask[distributed,dataframe]>=2024.4.1",
             "pyarrow>=7.0.0",
             "pandas>=2.0.2",
         ],
@@ -67,7 +67,7 @@ setup(
         "all": SQL_DEPENDENCIES
         + [
             "pyspark>=3.1.1",
-            "dask[distributed,dataframe]>=2023.5.0",
+            "dask[distributed,dataframe]>=2024.4.1",
             "dask-sql",
             "ray[data]>=2.4.0",
             "notebook",


### PR DESCRIPTION
Dear @goodwanghan and @kvnkho,

first things first: Thanks a stack for conceiving and maintaining this excellent library.

A few days ago, we [discovered a flaw with PyCaret and Dask](https://github.com/pycaret/pycaret/issues/3960#issuecomment-2045881422), and finally tracked it back to an incompatibility with Python 3.11.9, which was released on April 2, 2024, and is being rolled out on GHA runners by GitHub starting Apr 8, 2024, when it started to become more visible to downstream users like us.

- https://github.com/dask/dask/issues/11038

In order to fix the problem, it is advised to update to `dask>=2024.4.1`, which includes a relevant fix. Those patches bring in corresponding updates on behalf of downstream applications/frameworks, validating that approach after it tripped us.

- https://github.com/crate-workbench/mlflow-cratedb/pull/126
- https://github.com/pycaret/pycaret/pull/3963

In the same spirit, this patch intends to fix Fugue on new and fresh installations, otherwise tripping users into this subtle dependency flaw. [^1]

With kind regards,
Andreas.

[^1]: Let us know if you absolutely need to retain compatibility with Python 3.8, which may not be taken for granted after applying this patch as is, so we may look into this detail once again.
