### PR TITLE
Allow Pandas upper bound to be `<3`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
             "ray[data]>=2.5.0",
             "duckdb>=0.5.0",
             "pyarrow>=7.0.0",
-            "pandas<2.2",
+            "pandas<3",
         ],
         "duckdb": SQL_DEPENDENCIES
         + [
@@ -63,7 +63,7 @@ setup(
             "numpy",
         ],
         "polars": ["polars"],
-        "ibis": SQL_DEPENDENCIES + ["ibis-framework[pandas]", "pandas<2.2"],
+        "ibis": SQL_DEPENDENCIES + ["ibis-framework[pandas]", "pandas<3"],
         "notebook": ["notebook", "jupyterlab", "ipython>=7.10.0"],
         "all": SQL_DEPENDENCIES
         + [
@@ -76,7 +76,7 @@ setup(
             "ipython>=7.10.0",
             "duckdb>=0.5.0",
             "pyarrow>=6.0.1",
-            "pandas>=2.0.2,<2.2",  # because of Ray and ibis
+            "pandas>=2.0.2,<3",  # because of Ray and ibis
             "ibis-framework[pandas]",
             "polars",
         ],


### PR DESCRIPTION
Hi!

There's nothing explicitly requiring pandas to be lower than 2.2. At the same time, the latest Pandas provides useful improvements, e.g.: [this one](https://pandas.pydata.org/docs/dev/whatsnew/v2.2.0.html#dedicated-string-data-type-backed-by-arrow-by-default).