### PR TITLE
Adding security warnings to Flask RPCServer

### DIFF
--- a/fugue/rpc/flask.py
+++ b/fugue/rpc/flask.py
@@ -78,15 +78,14 @@ class FlaskRPCServer(RPCServer):
 
     def start_server(self) -> None:
         """Start Flask RPC server"""
-        self._log.warning(
+        msg = (
             "Starting RPC server on %s:%s. "
             "This server has no authentication and relies on network isolation. "
             "Ensure proper VPC/firewall configuration in production. "
             "See https://fugue-tutorials.readthedocs.io/tutorials/resources/"
-            "security.html",
-            self._host,
-            self._port,
+            "security.html"
         )
+        self._log.warning(msg, self._host, self._port)
         app = Flask("FlaskRPCServer")
         app.route("/invoke", methods=["POST"])(self._invoke)
         self._server = FlaskRPCServer._Thread(app, self._host, self._port)


### PR DESCRIPTION
## Background

A security researcher (@Chenpinji) reported concerns about the Flask RPC server binding to 0.0.0.0 without authentication, which could pose risks in multi-tenant cluster environments.

## Problem

  The FlaskRPCServer is designed for distributed computing use cases where:
  - A Spark driver starts an RPC server for executor callbacks
  - Executors (running on worker nodes) send results back to the driver in real-time
  - Communication happens within a single user's trusted Spark session

In typical deployments (AWS EMR, Databricks, GCP Dataproc), Spark clusters run in isolated VPCs where the RPC port is only accessible within the cluster network, protected by cloud security groups and firewalls.

However, security concerns arise in these scenarios:
1. Multi-tenant clusters: In shared environments (e.g., long-running Databricks clusters), one user's RPC server could theoretically be accessible to another user on the same cluster network
2. Misconfigured networks: Users might accidentally expose the RPC port to broader networks without proper firewall rules
3. On-premise deployments: Clusters without proper network segmentation could allow cross-team access

## Security Model Alignment with Distributed frameworks

Fugue's RPC server follows the same security model as the distributed computing frameworks it supports:

  Apache Spark:
  - Driver ports (for executor communication) are exposed on the cluster network
  - Does NOT enable authentication by default (spark.authenticate=false)
  - Production deployments rely on network isolation (VPCs, security groups, firewall
  rules)
  - Binds to actual network IP (spark.driver.host) rather than 0.0.0.0

  Dask:
  - Distributed scheduler binds to 0.0.0.0 by default (all interfaces)
  - Has separate --listen-address (bind) and --contact-address (advertise) similar to
  Spark's model
  - No authentication in default configuration
  - Relies on network-level security controls

  Ray:
  - Requires explicit --node-ip-address to specify binding interface
  - Does not bind to 0.0.0.0 by default
  - No authentication by default
  - Workers connect to head node's specific IP address
  - Security depends on network isolation

  Common pattern across all frameworks:
  - Network-accessible endpoints for distributed communication
  - Authentication NOT enabled by default
  - Security relies on infrastructure controls (VPCs, firewalls, security groups)
  - Multi-tenant environments require additional network segmentation

**Fugue's RPC port has identical exposure to these frameworks' communication ports. If an attacker can reach the Fugue RPC endpoint in a multi-tenant cluster, they can also reach the unauthenticated services of the underlying distributed framework.**

## Changes Made

Added a security warning that logs when the Flask RPC server starts:

WARNING: Starting RPC server on <host>:<port>. This server has no authentication and relies on network isolation. Ensure proper VPC/firewall configuration in production. See https://fugue-tutorials.readthedocs.io/tutorials/resources/security/index.html

## Considered alternatives:

1. . Token-based authentication: Would require generating secrets, distributing them to executors, and validating on each request. This adds complexity and diverges from how Spark operates by default.
2. Spark auth integration (spark.authenticate.secret): Could support this for users who enable Spark authentication, but it's rarely used in practice and doesn't solve the default case.
3. Change binding from 0.0.0.0 to 127.0.0.1: Would break distributed functionality since executors on remote worker nodes couldn't connect back to the driver.

##  Decision rationale

Organizations concerned about multi-tenant clusters should use the same protections they use for Spark (network segmentation, dedicated clusters per tenant, or enabling authentication at the Spark level)

## Pickle Serialization

The RPC implementation uses cloudpickle for serialization, which can execute arbitrary code during deserialization. We evaluated replacing pickle with safer alternatives (JSON, MessagePack, or restricted unpicklers), but this is not feasible without breaking core functionality. The RPC system must serialize arbitrary Python objects including functions, lambdas, and closures - a fundamental requirement for Fugue's distributed callback execution model. This aligns with Spark, Dask, and Ray, which all use cloudpickle/pickle for function serialization because they are designed for executing arbitrary user code in distributed environments. Security comes from network isolation, not from preventing code execution. The decision is to keep cloudpickle and clearly document the trust model through the warning message.

## Added Documentation:

The warning message directs users to https://fugue-tutorials.readthedocs.io/tutorials/resources/security/index.html for comprehensive security guidance.